### PR TITLE
Changed INSTALLDIR to fixed path to fix #422 and #600

### DIFF
--- a/wix/Includes/OpenJDK.Variables.wxi.template
+++ b/wix/Includes/OpenJDK.Variables.wxi.template
@@ -27,7 +27,7 @@
     <?define FeatureMainDescription="!(loc.JREFeatureMainDescription)" ?>
 
     <?define ProductCategory="JRE" ?>
-    <?define AppFolder="jre-$(var.ProductVersion)-$(var.JVM)" ?>
+    <?define AppFolder="jre-$(var.ProductMajorVersion)-$(var.JVM)" ?>
   <?else?>
     <?define ProductName="!(loc.JDKProductName)" ?>
     <?define ProductNameWithVersion="!(loc.JDKProductName) $(var.ProductVersionString) $(var.Arch)" ?>
@@ -36,7 +36,7 @@
     <?define FeatureMainDescription="!(loc.JDKFeatureMainDescription)" ?>
 
     <?define ProductCategory="JDK" ?>
-    <?define AppFolder="jdk-$(var.ProductVersion)-$(var.JVM)" ?>
+    <?define AppFolder="jdk-$(var.ProductMajorVersion)-$(var.JVM)" ?>
   <?endif?>
 
   <!-- Registry key change with new numbering format since Java 9 -->


### PR DESCRIPTION
By using only the Major version in the installdir path, the installation directory will not change during upgrades.

C:\Program Files\Eclipse Adoptium\jre-8-hotspot
C:\Program Files\Eclipse Adoptium\jdk-8-hotspot
C:\Program Files\Eclipse Adoptium\jre-11-hotspot
etc..